### PR TITLE
[MC-48] - Alignment problems in the password box

### DIFF
--- a/src/assets/scss/checkbox.scss
+++ b/src/assets/scss/checkbox.scss
@@ -14,17 +14,17 @@ label {
     color: $other-dark;
 }
 
-input {
+.input-box, .filled {
     position: relative;
     -webkit-appearance: none;
     -moz-appearance: none;
     appearance: none;
     margin: 8px;
-    box-sizing: content-box; // This line is bugging input password size
+    box-sizing: content-box;
     overflow: hidden;
 }
 
-input:before {
+.input-box:before, .filled:before {
     content: '';
     display: block;
     box-sizing: content-box;
@@ -34,17 +34,17 @@ input:before {
     transition: 0.2s border-color ease;
 }
 
-input:checked:before {
+.input-box:checked:before, .filled:checked:before {
     border-color: $accent-light;
     transition: 0.5s border-color ease;
 }
 
-input:disabled:before {
+.input-box:disabled:before, .filled:disabled:before {
     border-color: $accent-light;
     background-color: $accent-light;
 }
 
-input:after {
+.input-box:after, .filled::after {
     content: '';
     display: block;
     position: absolute;

--- a/src/assets/scss/checkbox.scss
+++ b/src/assets/scss/checkbox.scss
@@ -20,7 +20,7 @@ input {
     -moz-appearance: none;
     appearance: none;
     margin: 8px;
-    box-sizing: content-box;
+    box-sizing: content-box; // This line is bugging input password size
     overflow: hidden;
 }
 

--- a/src/assets/scss/input-password.scss
+++ b/src/assets/scss/input-password.scss
@@ -5,6 +5,7 @@
 
 // Label name => 'Senha'
 .password-label {
+    font-size: 16px;
     font-weight: bold;
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
     margin-bottom: 12px;
@@ -18,12 +19,14 @@
     background-color: $primary-dark;
     border: 2px solid $accent-light;
     border-radius: 20px;
+    height: 50px;
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
     padding-left: 35px;
     padding-top: 5px;
 }
 
 .password-input::placeholder {
+    font-size: 16px;
     color: $other-dark;
 }
 
@@ -31,7 +34,7 @@
 .fa-solid {
     color: $other-dark;
     position: relative;
-    top: 67px;
+    top: 71px;
     left: 17px;
     z-index: 1;
 }
@@ -40,6 +43,6 @@
     display: flex;
     flex-direction: row-reverse;
     position: relative;
-    top: -27px;
+    top: -31px;
     left: -17px; 
 }

--- a/src/assets/scss/input-password.scss
+++ b/src/assets/scss/input-password.scss
@@ -31,13 +31,15 @@
 .fa-solid {
     color: $other-dark;
     position: relative;
-    top: 44px;
+    top: 67px;
     left: 17px;
     z-index: 1;
 }
 
 .eye-icon {
+    display: flex;
+    flex-direction: row-reverse;
     position: relative;
-    top: -31px;
-    left: 266px;
+    top: -27px;
+    left: -17px; 
 }

--- a/src/assets/scss/input-password.scss
+++ b/src/assets/scss/input-password.scss
@@ -7,9 +7,8 @@
 .password-label {
     font-weight: bold;
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
-    margin-bottom: 10px;
-    margin-top: 10px;
-    margin-left: -10px;
+    margin-bottom: 12px;
+    margin-left: 15px;
 }
 
 // Input Password => placeholder => 'Senha'
@@ -20,13 +19,12 @@
     border: 2px solid $accent-light;
     border-radius: 20px;
     box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.1);
-    padding-left: 38px;
-    padding-top: 8px;
+    padding-left: 35px;
+    padding-top: 5px;
 }
 
 .password-input::placeholder {
     color: $other-dark;
-    margin-top: 2px;
 }
 
 // Icons
@@ -35,6 +33,7 @@
     position: relative;
     top: 44px;
     left: 17px;
+    z-index: 1;
 }
 
 .eye-icon {

--- a/src/pages/components/index.html
+++ b/src/pages/components/index.html
@@ -17,16 +17,10 @@
 
     <div class="row password input">
         <p>Password</p>
-        <div class="container-fluid col-md-4 password-box-enter" id="password">
+        <div class="container-fluid password-box-enter" id="password">
             <i class="fa-solid fa-lock lock-icon"></i>
             <label for="control-label" class="password-label">Senha</label>
-            <input
-                type="password"
-                id="pw-input"
-                class="form-control password-input"
-                placeholder="Senha"
-                required="required"
-            />
+            <input type="password" id="pw-input" class="form-control password-input" placeholder="Senha" required="required">
             <i class="fa-solid fa-eye-slash eye-icon"></i>
         </div>
     </div>

--- a/src/pages/components/style.scss
+++ b/src/pages/components/style.scss
@@ -6,6 +6,7 @@
 
 @import '@/assets/scss/input-box.scss';
 @import '@/assets/scss/checkbox.scss';
+
 // page scss
 .header {
     display: flex;
@@ -27,10 +28,13 @@
 
 // Password Box
 .password-box-enter {
+    background-color: $primary-dark;
     color: $other-light;
     box-shadow: 2px 2px 4px rgba(27, 15, 15, 0.1);
     padding: 10px;
     margin-top: 20px;
+    margin-bottom: 20px;
+    min-width: 200px;
 }
 
 .container-text-input-box {


### PR DESCRIPTION
# Feature/Issue Description
Alignment problems in the password box and conflict with other CSS archives.

# Changes Summary
- Changed checkbox.scss tag names;
- Fixed eye and padlock icon positions to adapt size.

# How Has This Been Tested?
- To test the code, I ran the application, went to components and validated the positions on localhost.


# Images (Opcional)
![image](https://user-images.githubusercontent.com/99288851/161319760-cc9ecff8-122a-4f57-bb6f-f258b334881b.png)
![image](https://user-images.githubusercontent.com/99288851/161319780-91dd89e9-6f19-4e40-8c41-aeee93a5c631.png)

